### PR TITLE
Update `OtelLogStorageFactory` to use last `workflow-api` changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
   <properties>
     <revision>3</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <opentelemetry.version>1.49.0</opentelemetry.version>
     <jenkins-opentelemetry.version>1.49.0.77.va_c69ec2472c0</jenkins-opentelemetry.version>
@@ -157,13 +157,20 @@
       <artifactId>elasticsearch-java</artifactId>
       <version>${elasticstack.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
         <!-- Jenkins does not use JSR 305 annotations -->
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
         </exclusion>
         <exclusion>
-          <!-- provided by org.jenkins-ci.plugins:apache-httpcomponents-client-5-api -->
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
@@ -172,7 +179,6 @@
           <artifactId>opentelemetry-api</artifactId>
         </exclusion>
         <exclusion>
-          <!-- provided by org.jenkins-ci.plugins:apache-httpcomponents-client-5-api -->
           <groupId>org.apache.httpcomponents.client5</groupId>
           <artifactId>httpclient5</artifactId>
         </exclusion>
@@ -525,10 +531,6 @@
       <version>1.21.3</version>
       <scope>test</scope>
       <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
   <properties>
     <revision>3</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <opentelemetry.version>1.49.0</opentelemetry.version>
     <jenkins-opentelemetry.version>1.49.0.75.v66006f513b_1f</jenkins-opentelemetry.version>
@@ -149,6 +149,22 @@
         <artifactId>parsson</artifactId>
         <version>1.1.7</version>
       </dependency>
+      <dependency>
+        <!-- depends on https://github.com/jenkinsci/workflow-api-plugin/pull/417 -->
+        <!-- TODO remove when in bom -->
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-api</artifactId>
+        <version>1404.vb_1e6d0166a_33</version>
+      </dependency>
+      <dependency>
+        <!-- depends on https://github.com/jenkinsci/workflow-api-plugin/pull/417 -->
+        <!-- TODO remove when in bom -->
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-api</artifactId>
+        <version>1404.vb_1e6d0166a_33</version>
+        <scope>test</scope>
+        <classifier>tests</classifier>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -175,6 +191,16 @@
           <!-- provided by org.jenkins-ci.plugins:apache-httpcomponents-client-5-api -->
           <groupId>org.apache.httpcomponents.client5</groupId>
           <artifactId>httpclient5</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- provided by org.jenkins-ci.plugins:jackson2-api -->
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- provided by org.jenkins-ci.plugins:jackson2-api -->
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -525,10 +551,6 @@
       <version>1.21.3</version>
       <scope>test</scope>
       <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <opentelemetry.version>1.49.0</opentelemetry.version>
-    <jenkins-opentelemetry.version>1.49.0.75.v66006f513b_1f</jenkins-opentelemetry.version>
+    <jenkins-opentelemetry.version>1.49.0.77.va_c69ec2472c0</jenkins-opentelemetry.version>
     <opentelemetry-instrumentation.version>2.15.0</opentelemetry-instrumentation.version>
     <opentelemetry-semconv.version>1.32.0</opentelemetry-semconv.version>
     <opentelemetry-contrib.version>1.46.0-alpha</opentelemetry-contrib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <opentelemetry-semconv.version>1.32.0</opentelemetry-semconv.version>
     <opentelemetry-contrib.version>1.46.0-alpha</opentelemetry-contrib.version>
     <useBeta>true</useBeta>
-    <elasticstack.version>9.0.4</elasticstack.version>
+    <elasticstack.version>9.1.0</elasticstack.version>
     <error-prone.version>2.40.0</error-prone.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,14 +154,14 @@
         <!-- TODO remove when in bom -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>1404.vb_1e6d0166a_33</version>
+        <version>1409.v96d6da_eed7f7</version>
       </dependency>
       <dependency>
         <!-- depends on https://github.com/jenkinsci/workflow-api-plugin/pull/417 -->
         <!-- TODO remove when in bom -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>1404.vb_1e6d0166a_33</version>
+        <version>1409.v96d6da_eed7f7</version>
         <scope>test</scope>
         <classifier>tests</classifier>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.18</version>
+    <version>5.19</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -163,6 +163,18 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         load();
     }
 
+    // needed by CloudBees HA see https://github.com/jenkinsci/opentelemetry-plugin/issues/1156
+    @Override
+    public void load() {
+        super.load();
+        if (currentOpenTelemetryConfiguration != null) {
+            // After reloading the XML configuration, we need to reconfigure the OTel SDK, otherwise the fields here
+            // may be out of sync with the SDK. We only do this as long as `configureOpenTelemetrySdk` has run at least
+            // once so that the first configuration happens during startup via `@Initializer` after applying CasC.
+            configureOpenTelemetrySdk();
+        }
+    }
+
     @Override
     public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         LOGGER.log(Level.FINE, "Configure...");

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -8,7 +8,6 @@ package io.jenkins.plugins.opentelemetry.job.log;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
-import hudson.ExtensionList;
 import hudson.model.Queue;
 import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.JenkinsControllerOpenTelemetry;
@@ -19,19 +18,19 @@ import io.opentelemetry.api.trace.Tracer;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.log.BrokenLogStorage;
 import org.jenkinsci.plugins.workflow.log.LogStorage;
 import org.jenkinsci.plugins.workflow.log.LogStorageFactory;
+import org.jenkinsci.plugins.workflow.log.LogStorageFactoryDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Binds Otel Logs to Pipeline logs.
  * <p>
  * See <a href="https://github.com/jenkinsci/pipeline-cloudwatch-logs-plugin/blob/pipeline-cloudwatch-logs-0.2/src/main/java/io/jenkins/plugins/pipeline_cloudwatch_logs/PipelineBridge.java">Pipeline Cloudwatch Logs - PipelineBridge</a>
  */
-@Extension
 public final class OtelLogStorageFactory implements LogStorageFactory, OpenTelemetryLifecycleListener {
 
     private static final Logger logger = Logger.getLogger(OtelLogStorageFactory.class.getName());
@@ -41,16 +40,17 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OpenTelem
         System.setProperty("org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING", "true");
     }
 
-    @Inject
-    JenkinsControllerOpenTelemetry jenkinsControllerOpenTelemetry;
+    private final JenkinsControllerOpenTelemetry jenkinsControllerOpenTelemetry;
 
-    @Nullable
-    private OtelTraceService otelTraceService;
+    private final OtelTraceService otelTraceService;
 
-    private Tracer tracer;
+    private final Tracer tracer;
 
-    static OtelLogStorageFactory get() {
-        return ExtensionList.lookupSingleton(OtelLogStorageFactory.class);
+    @DataBoundConstructor
+    public OtelLogStorageFactory() {
+        jenkinsControllerOpenTelemetry = JenkinsControllerOpenTelemetry.get();
+        otelTraceService = OtelTraceService.get();
+        tracer = jenkinsControllerOpenTelemetry.getDefaultTracer();
     }
 
     /**
@@ -62,7 +62,7 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OpenTelem
     @Override
     public LogStorage forBuild(@NonNull final FlowExecutionOwner owner) {
         LogStorage ret = null;
-        if (!getJenkinsControllerOpenTelemetry().isLogsEnabled()) {
+        if (!jenkinsControllerOpenTelemetry.isLogsEnabled()) {
             logger.log(Level.FINE, () -> "OTel Logs disabled");
             return ret;
         }
@@ -86,35 +86,23 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OpenTelem
         if (exec instanceof Run<?, ?> run && run.getAction(MonitoringAction.class) != null) {
             // it's a pipeline with monitoring data
             logger.log(Level.FINEST, () -> "forExec(" + run + ")");
-            ret = new OtelLogStorage(run, getOtelTraceService(), tracer);
+            ret = new OtelLogStorage(run, otelTraceService, tracer);
         }
         return ret;
     }
 
-    /**
-     * Workaround dependency injection problem. @Inject doesn't work here
-     */
-    @NonNull
-    private JenkinsControllerOpenTelemetry getJenkinsControllerOpenTelemetry() {
-        if (jenkinsControllerOpenTelemetry == null) {
-            jenkinsControllerOpenTelemetry = JenkinsControllerOpenTelemetry.get();
+    @Extension()
+    @Symbol("opentelemetry")
+    public static final class DescriptorImpl extends LogStorageFactoryDescriptor<OtelLogStorageFactory> {
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Open Telemetry";
         }
-        return jenkinsControllerOpenTelemetry;
-    }
 
-    /**
-     * Workaround dependency injection problem. @Inject doesn't work here
-     */
-    @NonNull
-    private OtelTraceService getOtelTraceService() {
-        if (otelTraceService == null) {
-            otelTraceService = OtelTraceService.get();
+        @Override
+        public LogStorageFactory getDefaultInstance() {
+            return new OtelLogStorageFactory();
         }
-        return otelTraceService;
-    }
-
-    @PostConstruct
-    public void postConstruct() {
-        this.tracer = jenkinsControllerOpenTelemetry.getDefaultTracer();
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -92,12 +92,12 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OpenTelem
     }
 
     @Extension()
-    @Symbol("opentelemetry")
+    @Symbol("openTelemetry")
     public static final class DescriptorImpl extends LogStorageFactoryDescriptor<OtelLogStorageFactory> {
         @NonNull
         @Override
         public String getDisplayName() {
-            return "Open Telemetry";
+            return "OpenTelemetry";
         }
 
         @Override

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfigurationIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfigurationIntegrationTest.java
@@ -1,0 +1,66 @@
+package io.jenkins.plugins.opentelemetry;
+
+import io.jenkins.plugins.opentelemetry.semconv.JenkinsMetrics;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporterUtils;
+import io.opentelemetry.semconv.ServiceAttributes;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Optional;
+import jenkins.model.Jenkins;
+import org.junit.After;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+
+@WithJenkins
+public class JenkinsOpenTelemetryPluginConfigurationIntegrationTest {
+    static {
+        OpenTelemetryConfiguration.TESTING_INMEMORY_MODE = true;
+    }
+
+    @BeforeEach() public void before() {
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @After
+    public void after() throws Exception {
+        InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.reset();
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/opentelemetry-plugin/issues/1156")
+    public void configLoadReconfiguresOtelSdk(JenkinsRule r) throws Exception {
+        var extension = JenkinsOpenTelemetryPluginConfiguration.get();
+        extension.setEndpoint("http://localhost:4317");
+        extension.setServiceName("name-1");
+        r.configRoundtrip();
+        // Not ideal, but Descriptor.getConfigFile is protected.
+        var configXmlPath = new File(Jenkins.get().getRootDir(), extension.getId() + ".xml").toPath();
+        var savedConfigXml = Files.readString(configXmlPath);
+
+        extension.setServiceName("name-2");
+        r.configRoundtrip();
+        await().until(() -> getServiceNameFromLastExportedMetric(JenkinsMetrics.JENKINS_QUEUE_COUNT), is("name-2"));
+
+        // Check that overwriting the config and calling Descriptor.load is enough to reconfigure the OTel SDK.
+        Files.writeString(configXmlPath, savedConfigXml);
+        extension.load();
+        await().until(() -> getServiceNameFromLastExportedMetric(JenkinsMetrics.JENKINS_QUEUE_COUNT), is("name-1"));
+    }
+
+    private static String getServiceNameFromLastExportedMetric(String metricName) {
+        Map<String, MetricData> exportedMetrics = InMemoryMetricExporterUtils.getLastExportedMetricByMetricName(
+                InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems());
+        var metric = Optional.ofNullable(exportedMetrics.get(metricName));
+        return metric.map(m -> m.getResource().getAttributes().get(ServiceAttributes.SERVICE_NAME)).orElse(null);
+    }
+
+}


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-api-plugin/pull/417 changes the `LogStorageFactory` API in an incompatible way, see that PR for details and justification.
This PR adapts to the upstream changes, and will need to be released roughly at the same time as that PR.
We are opening this draft PR to make sure the maintainers here are ok with the general idea and to help coordinate the release.

This PR applies the following changes:

* Updates `OtelLogStorageFactory` to use the `Describable`/`Descriptor` pattern, which requires some minor changes due to `OtelLogStorageFactory` no longer being a singleton `@Extension`
* Updates the baseline in `pom.xml` as required by the `workflow-api` update, which requires some changes to fix dependency issues and upper bounds conflicts. We can file these updates as a standalone PR if desired.

As the upstream changes allow users to configure functionality equivalent to `otel.logs.mirror_to_disk=true` mechanism in a generic way (other than the caveat of no longer being able to print a link to the observability platform into the logs dynamically), the current plugin won't need the `Tee*` classes anymore and the logging code can be simplified if desired. We can handle this simplification in a followup PR if you are interested.